### PR TITLE
feat: display coupon discounts on course listing and detail pages

### DIFF
--- a/src/components/courses/CourseCard.tsx
+++ b/src/components/courses/CourseCard.tsx
@@ -25,6 +25,7 @@ type CourseCardProps = {
   price: number;
   originalPrice?: number;
   thumbnail?: string;
+  applicableCoupon?: { discount_percentage: number };
 };
 
 export const CourseCard = ({
@@ -38,7 +39,11 @@ export const CourseCard = ({
   price,
   originalPrice,
   thumbnail,
+  applicableCoupon,
 }: CourseCardProps) => {
+  const discountPercentage = applicableCoupon?.discount_percentage ?? 0;
+  const discountAmount = Math.round((price * discountPercentage) / 100);
+  const finalPrice = price - discountAmount;
   return (
     <Link href={`/courses/${slug}`}>
       <Card className="overflow-hidden transition-shadow hover:shadow-lg cursor-pointer">
@@ -112,12 +117,21 @@ export const CourseCard = ({
 
             {/* Right side: Pricing */}
             <div className="flex flex-col items-end gap-0.5 sm:gap-1">
+              {applicableCoupon && (
+                <div className="mb-1 rounded-md border border-emerald-200 bg-emerald-50 px-2 py-1 text-xs text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-200">
+                  <span className="font-semibold">{discountPercentage}% хямдрал</span> ·{" "}
+                  {discountAmount.toLocaleString()}₮ хэмнэнэ
+                </div>
+              )}
               <span className="text-lg font-bold sm:text-xl">
-                {price.toLocaleString()}₮
+                {applicableCoupon ? finalPrice.toLocaleString() : price.toLocaleString()}₮
               </span>
-              {originalPrice && (
+              {(applicableCoupon || originalPrice) && (
                 <span className="text-xs text-muted-foreground line-through sm:text-sm">
-                  {originalPrice.toLocaleString()}₮
+                  {applicableCoupon
+                    ? price.toLocaleString()
+                    : originalPrice?.toLocaleString()}
+                  ₮
                 </span>
               )}
             </div>

--- a/src/components/courses/CoursesClientWrapper.tsx
+++ b/src/components/courses/CoursesClientWrapper.tsx
@@ -19,6 +19,7 @@ type CoursesClientWrapperProps = {
   currentPage: number;
   totalPages: number;
   totalCount: number;
+  userCoupons?: Record<string, { discount_percentage: number }>;
 };
 
 export const CoursesClientWrapper = ({
@@ -28,6 +29,7 @@ export const CoursesClientWrapper = ({
   currentPage,
   totalPages,
   totalCount,
+  userCoupons,
 }: CoursesClientWrapperProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -164,7 +166,7 @@ export const CoursesClientWrapper = ({
               ))}
             </div>
           ) : (
-            <CoursesList courses={initialCourses} />
+            <CoursesList courses={initialCourses} userCoupons={userCoupons} />
           )}
 
           <CoursesPagination

--- a/src/components/courses/CoursesList.tsx
+++ b/src/components/courses/CoursesList.tsx
@@ -3,9 +3,10 @@ import type { CourseWithCategories } from "@/types/database";
 
 type CoursesListProps = {
   courses: CourseWithCategories[];
+  userCoupons?: Record<string, { discount_percentage: number }>;
 };
 
-export const CoursesList = ({ courses }: CoursesListProps) => {
+export const CoursesList = ({ courses, userCoupons }: CoursesListProps) => {
   if (courses.length === 0) {
     return (
       <div className="text-center py-12">
@@ -37,7 +38,13 @@ export const CoursesList = ({ courses }: CoursesListProps) => {
           thumbnail: course.thumbnail_url || undefined,
         };
 
-        return <CourseCard key={course.id} {...courseProps} />;
+        return (
+          <CourseCard
+            key={course.id}
+            {...courseProps}
+            applicableCoupon={userCoupons?.[course.id]}
+          />
+        );
       })}
     </div>
   );

--- a/src/components/courses/detail/CourseSidebar.tsx
+++ b/src/components/courses/detail/CourseSidebar.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
-import { Play } from "lucide-react";
+import { Play, CheckCircle } from "lucide-react";
 import { EnrollButton } from "./EnrollButton";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import type { ApplicableCoupon } from "@/types/shop";
 
 type CourseSidebarProps = {
   courseId: string;
@@ -11,6 +13,7 @@ type CourseSidebarProps = {
   continueButtonUrl: string | null;
   isEnrolled: boolean;
   hasPurchased: boolean;
+  applicableCoupon?: ApplicableCoupon | null;
 };
 
 export const CourseSidebar = ({
@@ -22,7 +25,11 @@ export const CourseSidebar = ({
   continueButtonUrl,
   isEnrolled,
   hasPurchased,
+  applicableCoupon,
 }: CourseSidebarProps) => {
+  const discountPercentage = applicableCoupon?.discount_percentage ?? 0;
+  const discountAmount = Math.round((price * discountPercentage) / 100);
+  const finalPrice = price - discountAmount;
   return (
     <div className="sticky top-4">
       <div className="border rounded-lg overflow-hidden bg-white">
@@ -52,14 +59,41 @@ export const CourseSidebar = ({
 
         {/* Pricing & Actions */}
         <div className="p-6">
+          {applicableCoupon && (
+            <Alert className="mb-4 bg-emerald-50 border-emerald-200 dark:bg-emerald-950 dark:border-emerald-800">
+              <CheckCircle className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+              <AlertTitle className="text-emerald-900 dark:text-emerald-100">
+                Купон идэвхжсэн!
+              </AlertTitle>
+              <AlertDescription className="text-emerald-800 dark:text-emerald-200">
+                {discountPercentage === 100 ? (
+                  <>
+                    Та энэ хичээлийг <strong>100% үнэгүй</strong> авах эрхтэй
+                    байна.
+                  </>
+                ) : (
+                  <>
+                    Та <strong>{discountPercentage}% хямдралтай</strong>{" "}
+                    худалдан авна.
+                    <br />
+                    Хэмнэлт: <strong>{discountAmount.toLocaleString()}₮</strong>
+                  </>
+                )}
+              </AlertDescription>
+            </Alert>
+          )}
+
           <div className="mb-6">
             <div className="flex items-baseline gap-2">
               <span className="text-3xl font-bold">
-                {price.toLocaleString()}₮
+                {applicableCoupon ? finalPrice.toLocaleString() : price.toLocaleString()}₮
               </span>
-              {originalPrice && (
+              {(applicableCoupon || originalPrice) && (
                 <span className="text-lg text-muted-foreground line-through">
-                  {originalPrice.toLocaleString()}₮
+                  {applicableCoupon
+                    ? price.toLocaleString()
+                    : originalPrice?.toLocaleString()}
+                  ₮
                 </span>
               )}
             </div>

--- a/src/types/shop.ts
+++ b/src/types/shop.ts
@@ -18,6 +18,12 @@ export type ShippingAddress = {
   addressLine: string;
 };
 
+export type ApplicableCoupon = {
+  id?: string;
+  discount_percentage: number;
+  expires_at?: string | null;
+};
+
 export type ProductMetadata = {
   course_id?: string;
   duration_hours?: number;


### PR DESCRIPTION
Implement coupon discount display across all course pages to show purchased discount coupons from XP shop. Users now see their active coupons with savings information on both course listing cards and detail page sidebar.

Changes:
- Add ApplicableCoupon type definition for type safety
- Fetch user coupons on course detail page with expiration validation
- Bulk fetch all user coupons on courses listing page (single query)
- Pass coupon data through component hierarchy
- Display emerald alert box with discount info on course detail sidebar
- Show compact discount badge on course listing cards
- Calculate and display discounted prices with strike-through originals
- Support both 50% and 100% discount coupons
- Handle unauthenticated users (no discounts shown)
- Match checkout page styling with emerald theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)